### PR TITLE
Export selected shapes to database feature

### DIFF
--- a/calipso/Calipso.py
+++ b/calipso/Calipso.py
@@ -277,7 +277,7 @@ class Calipso(object):
         success = self.__shapemanager.save_db(only_selected)
         if success:
             logger.info('Success, saved to db')
-            tkMessageBox.showinfo('database', 'All objects saved to database')
+            tkMessageBox.showinfo('database', 'Objects saved to database')
         else:
             logger.error('No objects to be saved')
             tkMessageBox.showerror('database', 'No objects to be saved')

--- a/calipso/db.py
+++ b/calipso/db.py
@@ -173,7 +173,7 @@ class DatabaseManager(object):
         logger.info('Committing to database')
         session = self.__Session()
         # for every polygon object in the list except the end
-        for polygon in poly_list[:-1]:
+        for polygon in poly_list:
             # if the ID does not exist we have a new object to commit
             if polygon.get_id() is None:
                 logger.debug('committing new shape: %s' % polygon.get_tag())

--- a/calipso/polygon/manager.py
+++ b/calipso/polygon/manager.py
@@ -373,9 +373,10 @@ class ShapeManager(object):
             return False
         today = datetime.utcnow().replace(microsecond=0)
         if(only_selected):
-            db.commit_to_db(self.__selected_list, today, self.__hdf)
+            db.commit_to_db( self.__selected_shapes, today, self.__hdf)
         else:
-            db.commit_to_db(self.__current_list, today, self.__hdf)
+            # Must account for dummy object at end of current list
+            db.commit_to_db(self.__current_list[:-1], today, self.__hdf)
         return True
 
     def save_json(self, filename=''):


### PR DESCRIPTION
Implements https://github.com/Syntaf/vocal/issues/81

The menu bar now has a new addition, `Export selected to Database`. This option will only export those objects currently selected.

Also refactored `commit_to_db` within `db.py` to instead iterate over the entire list. This way we can pass either `current_list[:-1]` or `selected_shapes` and have them iterate over the list correctly. If this wasn't changed we would need to copy selected_shapes, append a dummy object, _then_ pass it since the function loops through all but the last. Our `selected_shapes` list does not contain a dummy object at the end like `current_list`. 
