### PR TITLE
Update Log to save errors in seperate .log file

### DIFF
--- a/calipso/Calipso.py
+++ b/calipso/Calipso.py
@@ -24,7 +24,7 @@ from constants import Plot, PATH, ICO
 import constants
 from exctractdialog import ExtractDialog
 from importdialog import ImportDialog
-from log.log import logger
+from log.log import logger, error_check
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.figure import Figure
 from plot.plot_depolar_ratio import render_depolarized
@@ -659,15 +659,18 @@ class Calipso(object):
                 logger.info('Saving shapes')
                 saved = self.save_json()
                 if saved:
+                    error_check()
                     self.__root.destroy()
                 else:
                     return
             elif answer is False:
                 logger.info('Dumping unsaved shapes')
+                error_check()
                 self.__root.destroy()
             elif answer is None:
                 return
         else:
+            error_check()
             self.__root.destroy()
 
 

--- a/calipso/log/log.py
+++ b/calipso/log/log.py
@@ -4,8 +4,11 @@
 #   @authors: Grant Mercer, Nathan Qian
 ###################################
 import logging.config
+import re
+import shutil
 import sys
-import os
+from time import strftime as time
+
 from constants import PATH
 
 config = {
@@ -28,7 +31,8 @@ config = {
                     'class': 'logging.StreamHandler',
                     'formatter': 'logfileformatter',
                     'level': 'NOTSET',
-                    'stream': 'ext://sys.stdout'}
+                    'stream': 'ext://sys.stdout'
+                    },
                 },
           'loggers': {
                 '': {
@@ -39,10 +43,28 @@ config = {
                 }
           }
 
+
 def uncaught_exception(exctype, value, tb):
     logger.exception("Uncaught exception: {0}".format(str(value)))
     sys.__excepthook__(exctype, value, tb)
-    
+
+def error_check():
+    log = PATH + '/log/trace.log'
+    error = False
+
+    with open(log) as f:
+        for line in f:
+            error = re.search('ERROR', line)
+
+        if error:
+            logger.info('Error found, log copied')
+            copy = PATH + '/log/error' + time("%Y-%m-%d-%H-%M-%S") + '.log'
+            shutil.copy(log, copy)
+            return
+        else:
+            logger.info('No Errors found')
+            return
+
 sys.excepthook = uncaught_exception
 # logging.config.fileConfig(r'/home/gdev/Github/vocal/calipso/log/logging.ini',
 # disable_existing_loggers=False)


### PR DESCRIPTION
updated log and Calipso so that upon close, a method is called to check the log for errors, and copy the log to a separate file if any are found. This second file is not overwritten upon subsequent sessions of VOCAL
