### PR TITLE
Fix for depolarization bug

### DIFF
--- a/calipso/plot/avg_lidar_data.py
+++ b/calipso/plot/avg_lidar_data.py
@@ -28,8 +28,8 @@ def avg_horz_data(data, N):
     nProfiles = data.shape[1]                                                  
 
 
-    nOutProfiles = np.floor(nProfiles/N) 
-    out = np.zeros((nAlts, nOutProfiles))
+    nOutProfiles = np.floor(nProfiles/N)
+    out = np.zeros((int(nAlts), int(nOutProfiles)))
   
     for i in range(0, int(nOutProfiles) - 1): 
         out[:, i] = ma.mean(data[:, i*N:(i+1)*N - 1], axis=1)  

--- a/calipso/plot/uniform_alt_2.py
+++ b/calipso/plot/uniform_alt_2.py
@@ -32,10 +32,10 @@ def uniform_alt_2(max_altitude, old_altitude_array):
 
     new_length = new_num_bins + len(alt2)
 
-    new_alt = np.zeros(new_length)
-    new_alt[new_num_bins:new_length] = alt2
+    new_alt = np.zeros(int(new_length))
+    new_alt[int(new_num_bins):int(new_length)] = alt2
 
     upper_altitudes =  (np.arange(new_num_bins) + 1.)*D_ALT
-    new_alt[:new_num_bins] = new_alt[new_num_bins] + upper_altitudes[::-1]
+    new_alt[:int(new_num_bins)] = new_alt[int(new_num_bins)] + upper_altitudes[::-1]
 
     return new_alt


### PR DESCRIPTION
Fixes #120. Numpy was expecting integer data types in the indices for some of the code, so I used `int()` to change them from float64. I tested it with the .hdf provided in the wiki and it works fine.